### PR TITLE
Reset XP bar when game ends

### DIFF
--- a/src/main/java/net/trollyloki/murdermystery/game/MurderMysteryGame.java
+++ b/src/main/java/net/trollyloki/murdermystery/game/MurderMysteryGame.java
@@ -488,6 +488,8 @@ public class MurderMysteryGame extends Game {
                     plugin.getConfigString("titles.end.subtitles." + reason.name().toLowerCase()),
                     5, 100, 10);
 
+            player.setExp(0); // Reset XP bar
+
             player.setGameMode(GameMode.SPECTATOR); // put remaining players in spectator
         }
 


### PR DESCRIPTION
Most useless pull request ever

If the bow cooldown was active when the game ended, it will continue through the next game. This fixes that.

I was thinking it would be cool if the XP bar flashes a few times when the game ends - but honestly that might be ugly

